### PR TITLE
Remove code specific to Android in Toolbar Search

### DIFF
--- a/src/Toolbar/Toolbar.react.js
+++ b/src/Toolbar/Toolbar.react.js
@@ -195,11 +195,7 @@ function getStyles(props, context, state) {
     };
 }
 const addBackButtonListener = (callback) => {
-    if (Platform.OS !== 'ios') {
-        return BackAndroid.addEventListener('closeRequested', callback);
-    }
-
-    return () => {};
+    return BackAndroid.addEventListener('closeRequested', callback);
 };
 
 class Toolbar extends PureComponent {


### PR DESCRIPTION
All platforms (iOS, android and 3rd party windows) implements BackAndroid (iOS mocks it).